### PR TITLE
♻️ Add .js extensions to lit imports

### DIFF
--- a/components/d2l-questions-multi-select.js
+++ b/components/d2l-questions-multi-select.js
@@ -4,7 +4,7 @@ import '@brightspace-ui/core/components/inputs/input-checkbox.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/offscreen/offscreen.js';
 import 'd2l-polymer-siren-behaviors/store/entity-store.js';
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
 

--- a/components/d2l-questions-multiple-choice.js
+++ b/components/d2l-questions-multiple-choice.js
@@ -4,7 +4,7 @@ import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/offscreen/offscreen.js';
 import 'd2l-polymer-siren-behaviors/store/entity-store.js';
 import { Classes, Rels } from 'd2l-hypermedia-constants';
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
 import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';

--- a/components/d2l-questions-question.js
+++ b/components/d2l-questions-question.js
@@ -1,5 +1,5 @@
 import 'd2l-polymer-siren-behaviors/store/entity-store.js';
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { Classes } from 'd2l-hypermedia-constants';
 import { runAsync } from '@brightspace-ui/core/directives/run-async/run-async.js';
 


### PR DESCRIPTION
This PR makes backwards-compatible changes to prepare all repos for a Lit 2 upgrade. Since the changes are backwards compatible, it can be merged right away.

**Non-breaking change checklist:** 

- [x] Add missing `.js` extensions for lit-html or lit-element imports
- [x] `await requestUpdate` -> `await elem.updateComplete`
- [x] add non-null checks to shadowRoot accesses (not including test files)
- [x] ensure `undefined` is not passed into unsafeHTML calls
- [x] remove dynamic code from inside  `<template>` tags (Lit files only)
- [x] remove any dependencies on old Lit versions
- [x] audit `ifDefined` usages for null parameters

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.