### PR TITLE
Scy/us136115/fix switching questions & HTML support

### DIFF
--- a/components/d2l-questions-multiple-choice.js
+++ b/components/d2l-questions-multiple-choice.js
@@ -43,7 +43,7 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 				display: flex;
 				flex-wrap: nowrap;
 				align-items: flex-start;
-				padding-bottom: 1rem;
+				padding-bottom: 1.2rem;
 			}
 			.d2l-input-radio-label {
 				color: var(--d2l-color-galena);

--- a/components/d2l-questions-multiple-choice.js
+++ b/components/d2l-questions-multiple-choice.js
@@ -9,6 +9,7 @@ import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/st
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
 import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 
 class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 
@@ -76,14 +77,16 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 
 	render() {
 		const questionText = this.question.entity.getSubEntityByClass(Classes.questions.questionText);
+		const htmlQuestionText = unsafeHTML(questionText.properties.html);
+
 		if (this._choices !== undefined) {
 			return html`
-				<div class="d2l-questions-multiple-choice-question-text">${questionText.properties.html}</div>
+				<div class="d2l-questions-multiple-choice-question-text">${htmlQuestionText}</div>
 
 				<div class="d2l-questions-multiple-choice-group">
 					${this._choices.map((choice) => this._renderChoice(choice))}
 				</div>
-				`;
+			`;
 		}
 	}
 
@@ -115,8 +118,9 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 		const choices = await Promise.all(interactionEntity.entity.getSubEntitiesByClass(Classes.questions.simpleChoice).map(async choice => {
 			const choiceEntity = await this._getEntityFromHref(choice.href, false);
 			return {
+				href: choice.href,
+				htmlText: choiceEntity.entity.getSubEntityByClass(Classes.text.richtext).properties.html,
 				text: choiceEntity.entity.getSubEntityByClass(Classes.text.richtext).properties.text,
-				href: choice.href
 			};
 		}));
 		this._choices = choices;
@@ -132,6 +136,7 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 			const choiceHref = choice.getLinkByRel(Rels.Questions.identifier).href;
 			const choiceEntity = await this._getEntityFromHref(choiceHref, false);
 			return {
+				htmlText: choiceEntity.entity.getSubEntityByClass(Classes.text.richtext).properties.html,
 				text: choiceEntity.entity.getSubEntityByClass(Classes.text.richtext).properties.text,
 				selected: choice.hasClass(Classes.questions.selected),
 				correct: choice.hasClass(Classes.questions.correctResponse),
@@ -161,7 +166,7 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 						aria-label="${choice.text}">
 						${choice.text}
 					</label>
-			</div>
+				</div>
 			`;
 		}
 	}

--- a/components/d2l-questions-multiple-choice.js
+++ b/components/d2l-questions-multiple-choice.js
@@ -77,11 +77,14 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 
 	render() {
 		const questionText = this.question.entity.getSubEntityByClass(Classes.questions.questionText);
-		const htmlQuestionText = unsafeHTML(questionText.properties.html);
 
 		if (this._choices !== undefined) {
 			return html`
-				<div class="d2l-questions-multiple-choice-question-text">${htmlQuestionText}</div>
+				<div class="d2l-questions-multiple-choice-question-text">
+					<d2l-html-block>
+						${unsafeHTML(questionText.properties.html)}
+					</d2l-html-block>
+				</div>
 
 				<div class="d2l-questions-multiple-choice-group">
 					${this._choices.map((choice) => this._renderChoice(choice))}
@@ -164,7 +167,9 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 						<input type="radio" name="${this.radioGroupId}"
 						?checked=${choice.selected}
 						aria-label="${choice.text}">
-						${choice.text}
+						<d2l-html-block>
+							${unsafeHTML(choice.htmlText)}
+						</d2l-html-block>
 					</label>
 				</div>
 			`;
@@ -192,8 +197,10 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 			<div class="d2l-questions-multiple-choice-row d2l-body-compact">
 				${icon ? html`<d2l-icon icon="tier1:${icon}" class="${iconStyle}"></d2l-icon>` : html`<div class="d2l-questions-multiple-choice-without-icon"></div>`}
 				${choice.selected ? html`<d2l-questions-icons-radio-checked></d2l-questions-icons-radio-checked>` : html`<d2l-questions-icons-radio-unchecked></d2l-questions-icons-radio-unchecked>`}
-				<d2l-offscreen>${this.localize(lang)} ${choice.text}</d2l-offscreen>
-				<span aria-hidden="true">${choice.text}</span>
+				<d2l-offscreen>${this.localize(lang)}${choice.text}</d2l-offscreen>
+				<d2l-html-block aria-hitten="true">
+					${unsafeHTML(choice.htmlText)}
+				</d2l-html-block>
 			</div>`;
 	}
 

--- a/components/d2l-questions-multiple-choice.js
+++ b/components/d2l-questions-multiple-choice.js
@@ -42,15 +42,24 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 				color: var(--d2l-color-galena);
 				display: flex;
 				flex-wrap: nowrap;
-				height: 2.5rem;
+				align-items: flex-start;
+				padding-bottom: 1rem;
+			}
+			.d2l-input-radio-label {
+				color: var(--d2l-color-galena);
+				display: flex;
+				flex-wrap: nowrap;
+				align-items: flex-start;
 			}
 			.d2l-questions-multiple-choice-row d2l-questions-icons-radio-unchecked,
 			.d2l-questions-multiple-choice-row d2l-questions-icons-radio-checked {
 				margin-right: 0.3rem;
 				margin-top: -0.1rem;
+				flex: none;
 			}
 			.d2l-questions-multiple-choice-row d2l-icon {
 				margin-right: 0.3rem;
+				flex: none;
 			}
 			.d2l-questions-multiple-choice-incorrect-icon {
 				color: var(--d2l-color-cinnabar);
@@ -60,6 +69,7 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 			}
 			.d2l-questions-multiple-choice-without-icon {
 				width: 1.2rem;
+				flex: none;
 			}
 		`];
 	}

--- a/components/d2l-questions-multiple-choice.js
+++ b/components/d2l-questions-multiple-choice.js
@@ -198,7 +198,7 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 				${icon ? html`<d2l-icon icon="tier1:${icon}" class="${iconStyle}"></d2l-icon>` : html`<div class="d2l-questions-multiple-choice-without-icon"></div>`}
 				${choice.selected ? html`<d2l-questions-icons-radio-checked></d2l-questions-icons-radio-checked>` : html`<d2l-questions-icons-radio-unchecked></d2l-questions-icons-radio-unchecked>`}
 				<d2l-offscreen>${this.localize(lang)}${choice.text}</d2l-offscreen>
-				<d2l-html-block aria-hitten="true">
+				<d2l-html-block aria-hidden="true">
 					${unsafeHTML(choice.htmlText)}
 				</d2l-html-block>
 			</div>`;

--- a/components/d2l-questions-question.js
+++ b/components/d2l-questions-question.js
@@ -55,7 +55,7 @@ class D2lQuestionsQuestion extends (LitElement) {
 
 	render() {
 		return html`${runAsync(
-			this._questionType,
+			this._questionKey,
 			() => this._renderType(),
 			{
 				success: type => type

--- a/demo/data/multiple-choice/question.json
+++ b/demo/data/multiple-choice/question.json
@@ -21,7 +21,7 @@
       ],
       "properties": {
         "text": "Mark the item that is blue.",
-        "html": "Mark the item that is blue."
+        "html": "Mark the item that is <em>blue</em>."
       }
     },
     {

--- a/demo/data/multiple-choice/simple-choice-1.json
+++ b/demo/data/multiple-choice/simple-choice-1.json
@@ -11,8 +11,8 @@
         "https://questions.api.brightspace.com/rels/text"
       ],
       "properties": {
-        "text": "Apple",
-        "html": "Apple"
+        "text": "Mistake Apple",
+        "html": "<del>Mistake</del> Apple"
       }
     }
   ],

--- a/demo/data/multiple-choice/simple-choice-3.json
+++ b/demo/data/multiple-choice/simple-choice-3.json
@@ -11,8 +11,8 @@
         "https://questions.api.brightspace.com/rels/text"
       ],
       "properties": {
-        "text": "Oil",
-        "html": "Oil"
+        "text": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus.",
+        "html": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus."
       }
     }
   ],

--- a/demo/multi-select.html
+++ b/demo/multi-select.html
@@ -12,13 +12,6 @@
 	</head>
 	<body>
 		<d2l-demo-page page-title="D2l Questions - Given Multi-Select">
-			<h2>D2l-Questions-Question Multi Select</h2>
-			<d2l-demo-snippet>
-				<d2l-questions-question
-					question-href="./data/question-multi-select.json"
-					question-response-href="./data/question-multi-select-response.json"
-					token="token"></d2l-questions-question>
-			</d2l-demo-snippet>
 			<h2>D2l-Questions-Question Multi Select ReadOnly</h2>
 			<d2l-demo-snippet>
 				<d2l-questions-question

--- a/test/data/multiple-choice/question.json
+++ b/test/data/multiple-choice/question.json
@@ -21,7 +21,7 @@
       ],
       "properties": {
         "text": "Mark the item that is blue.",
-        "html": "Mark the item that is blue."
+        "html": "Mark the item that is <em>blue</em>."
       }
     },
     {

--- a/test/data/multiple-choice/simple-choice-1.json
+++ b/test/data/multiple-choice/simple-choice-1.json
@@ -11,8 +11,8 @@
         "https://questions.api.brightspace.com/rels/text"
       ],
       "properties": {
-        "text": "Apple",
-        "html": "Apple"
+        "text": "Mistake Apple",
+        "html": "<del>Mistake</del> Apple"
       }
     }
   ],

--- a/test/data/multiple-choice/simple-choice-3.json
+++ b/test/data/multiple-choice/simple-choice-3.json
@@ -11,8 +11,8 @@
         "https://questions.api.brightspace.com/rels/text"
       ],
       "properties": {
-        "text": "Oil",
-        "html": "Oil"
+        "text": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus.",
+        "html": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus."
       }
     }
   ],

--- a/test/data/multiple-choice/simple-choice-3.json
+++ b/test/data/multiple-choice/simple-choice-3.json
@@ -11,8 +11,8 @@
         "https://questions.api.brightspace.com/rels/text"
       ],
       "properties": {
-        "text": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus.",
-        "html": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus."
+        "text": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+        "html": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit."
       }
     }
   ],


### PR DESCRIPTION
- `d2l-questions-question` will now properly update when question/response hrefs change
- `d2l-questions-multiple-choice` will now properly display HTML content in question text / question response text
- Fix for long option text being cut off or overflowing

Includes vdiff updates for `d2l-questions-multiple-choice` that test for
- Question text containing HTML
- Option text containing HTML
- Long option text