### PR TITLE
BREAKING CHANGE: bump dependencies to lit 2 versions

### DIFF
--- a/components/d2l-questions-question.js
+++ b/components/d2l-questions-question.js
@@ -81,13 +81,14 @@ class D2lQuestionsQuestion extends (LitElement) {
 		if (this.questionResponseHref) {
 			this._questionResponse = await window.D2L.Siren.EntityStore.fetch(this.questionResponseHref, this.token);
 		}
-
-		if (this._question.entity.hasClass(Classes.questions.multipleChoice)) {
-			this._questionType = Classes.questions.multipleChoice;
-		} else if (this._question.entity.hasClass(Classes.questions.multiSelect)) {
-			this._questionType = Classes.questions.multiSelect;
-		} else if (this._question.entity.hasClass(Classes.questions.longAnswer)) { // previous naming convention for "Written Response" is "Long Answer", API response displaying LongAnswer currently
-			this._questionType = Classes.questions.longAnswer;
+		if (this._question && this._question.entity) {
+			if (this._question.entity.hasClass(Classes.questions.multipleChoice)) {
+				this._questionType = Classes.questions.multipleChoice;
+			} else if (this._question.entity.hasClass(Classes.questions.multiSelect)) {
+				this._questionType = Classes.questions.multiSelect;
+			} else if (this._question.entity.hasClass(Classes.questions.longAnswer)) { // previous naming convention for "Written Response" is "Long Answer", API response displaying LongAnswer currently
+				this._questionType = Classes.questions.longAnswer;
+			}
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -44,9 +44,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1",
+    "@brightspace-ui/core": "^2",
     "d2l-hypermedia-constants": "^6.60.0",
-    "lit-element": "^2",
-    "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1"
+    "lit-element": "^3",
+    "lit-html": "^2",
+    "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "npm run lint:eslint && npm run lint:lit && npm run lint:style",
     "lint:eslint": "eslint . --ext .js,.html",
-    "lint:lit": "lit-analyzer \"components/*.js\" --strict",
+    "lint:lit": "lit-analyzer \"components/*.js\" --strict --rules.no-unknown-tag-name off",
     "lint:style": "stylelint \"**/*.{js,html}\"",
     "start": "web-dev-server --app-index demo/index.html --node-resolve --open --watch",
     "test": "npm run lint && npm run test:headless",


### PR DESCRIPTION
This PR makes the breaking changes required to update to Lit 2 (`lit-html` 2 and `lit-element` 3). The Lit 2 upgrade will be a coordinated effort, so **this PR should not merge at this time**.

---
Breaking change checklist: 
- [x] Update `lit-html` -> `^2`, `lit-element` -> `^3`, `open-wc/testing` -> `^3` (if used)
- [x]  `createRenderRoot` usages -> move from LitElement to ReactiveElement
- [x]  Remove Dependabot Lit rules
- [x] Bump any dependencies to their Lit 2 versions
- [x] Remove any manual lifecycle calls to Lit 1 reactive controllers
- [x] Backwards-compatible changes merged: https://github.com/BrightspaceHypermediaComponents/questions/pull/31

Renamed API's:
- [x] `UpdatingElement` -> `ReactiveElement`
- [x] `@internalProperty` -> `@state` (we don't use TypeScript decorators)
- [x] `static getStyles()` -> `static finalizeStyles(styles)`
- [x] `_getUpdateComplete()` -> `getUpdateComplete()`
- [x] `NodePart` -> `ChildPart`

Testing checklist: 
- [x] CI/ unit tests pass
- [x] Local testing on demo pages
- [ ] Testing component in the LMS (Requires updated [d2l-consistent-evaluation](https://github.com/BrightspaceHypermediaComponents/consistent-evaluation))
---
For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.