### PR TITLE
Scy/html fix

### DIFF
--- a/components/d2l-questions-multiple-choice.js
+++ b/components/d2l-questions-multiple-choice.js
@@ -9,6 +9,7 @@ import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/st
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
 import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
+import { removeParagraphFormat } from './helpers/htmlTextHelper.js';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 
 class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
@@ -92,7 +93,7 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 			return html`
 				<div class="d2l-questions-multiple-choice-question-text">
 					<d2l-html-block>
-						${unsafeHTML(questionText.properties.html)}
+						${unsafeHTML(removeParagraphFormat(questionText.properties.html))}
 					</d2l-html-block>
 				</div>
 
@@ -178,7 +179,7 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 						?checked=${choice.selected}
 						aria-label="${choice.text}">
 						<d2l-html-block>
-							${unsafeHTML(choice.htmlText)}
+							${unsafeHTML(removeParagraphFormat(choice.htmlText))}
 						</d2l-html-block>
 					</label>
 				</div>
@@ -209,7 +210,7 @@ class D2lQuestionsMultipleChoice extends LocalizeDynamicMixin(LitElement) {
 				${choice.selected ? html`<d2l-questions-icons-radio-checked></d2l-questions-icons-radio-checked>` : html`<d2l-questions-icons-radio-unchecked></d2l-questions-icons-radio-unchecked>`}
 				<d2l-offscreen>${this.localize(lang)}${choice.text}</d2l-offscreen>
 				<d2l-html-block aria-hidden="true">
-					${unsafeHTML(choice.htmlText)}
+					${unsafeHTML(removeParagraphFormat(choice.htmlText))}
 				</d2l-html-block>
 			</div>`;
 	}

--- a/demo/data/multiple-choice/question.json
+++ b/demo/data/multiple-choice/question.json
@@ -21,7 +21,7 @@
       ],
       "properties": {
         "text": "Mark the item that is blue.",
-        "html": "Mark the item that is <em>blue</em>."
+        "html": "<p>Mark the item that is <em>blue</em>.</p>"
       }
     },
     {

--- a/demo/data/multiple-choice/simple-choice-3.json
+++ b/demo/data/multiple-choice/simple-choice-3.json
@@ -11,8 +11,8 @@
         "https://questions.api.brightspace.com/rels/text"
       ],
       "properties": {
-        "text": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus.",
-        "html": "<p>Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus.</p>"
+        "text": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+        "html": "<p>Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>"
       }
     }
   ],

--- a/demo/data/multiple-choice/simple-choice-3.json
+++ b/demo/data/multiple-choice/simple-choice-3.json
@@ -12,7 +12,7 @@
       ],
       "properties": {
         "text": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus.",
-        "html": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus."
+        "html": "<p>Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus.</p>"
       }
     }
   ],

--- a/test/data/multiple-choice/question.json
+++ b/test/data/multiple-choice/question.json
@@ -21,7 +21,7 @@
       ],
       "properties": {
         "text": "Mark the item that is blue.",
-        "html": "Mark the item that is <em>blue</em>."
+        "html": "<p>Mark the item that is <em>blue</em>.</p>"
       }
     },
     {

--- a/test/data/multiple-choice/simple-choice-3.json
+++ b/test/data/multiple-choice/simple-choice-3.json
@@ -11,8 +11,8 @@
         "https://questions.api.brightspace.com/rels/text"
       ],
       "properties": {
-        "text": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus.",
-        "html": "<p>Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus.</p>"
+        "text": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+        "html": "<p>Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>"
       }
     }
   ],

--- a/test/data/multiple-choice/simple-choice-3.json
+++ b/test/data/multiple-choice/simple-choice-3.json
@@ -11,8 +11,8 @@
         "https://questions.api.brightspace.com/rels/text"
       ],
       "properties": {
-        "text": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-        "html": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        "text": "Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus.",
+        "html": "<p>Oil and a really long answer for testing. lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam non metus eu urna feugiat rutrum. Sed ultricies nisl quis lobortis varius. Duis blandit elit sed nibh dictum, eget dapibus quam consequat. Fusce turpis neque, auctor ut elementum et, maximus eu tellus.</p>"
       }
     }
   ],


### PR DESCRIPTION
Using the helper to strip the `<p>` tags that are automatically added to plaintext by the HTML editor. Fixes extra padding for single-paragraph options.

Adds those `<p>` tags to the question text and one option in the demo/test data for for Multiple Choice questions.