### PR TITLE
fix: Release CI on maintenance branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
       - main
       - '[0-9]+.x'
       - '[0-9]+.[0-9]+.x'
+      - release/[0-9]+.[0-9]+.x
 jobs:
   release:
     if: "!contains(github.event.head_commit.message, 'skip ci')"


### PR DESCRIPTION
Release wasn't triggering on maintenance/release branch (this will be 'backported' to V2.x once it's confirmed working)