### PR TITLE
Removing WR bolding for question text

### DIFF
--- a/components/d2l-questions-written-response.js
+++ b/components/d2l-questions-written-response.js
@@ -41,7 +41,6 @@ class D2lQuestionWrittenResponse extends LocalizeDynamicMixin(LitElement) {
 				white-space: nowrap;
 			}
 			.d2l-questions-written-response-question-text {
-				font-weight: 700;
 				padding-bottom: 1.2rem;
 			}
 			.d2l-questions-written-response-question-initial-text {


### PR DESCRIPTION
Rally: https://rally1.rallydev.com/#/42960320374d/custom/236803223728?detail=%2Fuserstory%2F630811015961

Removing WR bolding for question text and matching question text styling for all question types (MC and WR).

![image](https://user-images.githubusercontent.com/24899889/161142530-65f0e632-0813-4eb5-bd93-ca0107e026a8.png)
