### PR TITLE
feat: US139463 Add RTL for current question types

### DIFF
--- a/components/d2l-questions-multi-select-presentational.js
+++ b/components/d2l-questions-multi-select-presentational.js
@@ -6,11 +6,12 @@ import '@brightspace-ui/core/components/offscreen/offscreen.js';
 import { css, html, LitElement } from 'lit';
 import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeQuestions } from '../localize-questions.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 //Database is using magic numbers
 const IS_CHECKED = '1';
-class D2lQuestionsMultiSelectPresentational extends LocalizeQuestions(LitElement) {
+class D2lQuestionsMultiSelectPresentational extends LocalizeQuestions(RtlMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -44,13 +45,26 @@ class D2lQuestionsMultiSelectPresentational extends LocalizeQuestions(LitElement
 				margin-right: 0.3rem;
 				margin-top: 0.1rem;
 			}
+			:host([dir="rtl"]) .d2l-questions-multi-select-row d2l-icon {
+				margin-left: 0.3rem;
+				margin-right: 0;
+			}
 			.d2l-questions-multi-select-row d2l-questions-icons-checkbox-unchecked,
 			.d2l-questions-multi-select-row d2l-questions-icons-checkbox-checked {
 				margin-right: 0.3rem;
 				margin-top: -0.1rem;
 			}
+			:host([dir="rtl"]) .d2l-questions-multi-select-row d2l-questions-icons-checkbox-unchecked,
+			:host([dir="rtl"]) .d2l-questions-multi-select-row d2l-questions-icons-checkbox-checked {
+				margin-left: 0.3rem;
+				margin-right: 0;
+			}
 			.d2l-questions-incorrect-answer-icon {
 				padding-left: 1.2rem;
+			}
+			:host([dir="rtl"]) .d2l-questions-incorrect-answer-icon {
+				padding-left: 0;
+				padding-right: 1.2rem;
 			}
 			.d2l-questions-multi-select-correct-response-icon {
 				color: var(--d2l-color-galena);
@@ -60,6 +74,9 @@ class D2lQuestionsMultiSelectPresentational extends LocalizeQuestions(LitElement
 			}
 			.d2l-questions-multi-select-correct-answer-icon {
 				color: var(--d2l-color-olivine);
+			}
+			:host([dir="rtl"]) .d2l-questions-multi-select-correct-answer-icon {
+				transform: scaleX(-1);
 			}
 		`];
 	}

--- a/components/d2l-questions-multiple-choice-presentational.js
+++ b/components/d2l-questions-multiple-choice-presentational.js
@@ -8,10 +8,11 @@ import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/st
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
 import { LocalizeQuestions } from '../localize-questions.js';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
-class D2lQuestionsMultipleChoicePresentational extends SkeletonMixin(LocalizeQuestions(LitElement)) {
+class D2lQuestionsMultipleChoicePresentational extends SkeletonMixin(RtlMixin(LocalizeQuestions(LitElement))) {
 
 	static get properties() {
 		return {
@@ -62,11 +63,19 @@ class D2lQuestionsMultipleChoicePresentational extends SkeletonMixin(LocalizeQue
 				margin-left: 26px;
 				width: 18px;
 			}
+			:host([skeleton][dir="rtl"]) .d2l-input-radio-skeleton-readonly {
+				margin-left: 0;
+				margin-right: 26px;
+			}
 			:host([skeleton]) .d2l-questions-html-block {
 				align-self: center;
 				height: 14px;
 				margin-left: 12px;
 				width: 134px;
+			}
+			:host([skeleton][dir="rtl"]) .d2l-questions-html-block {
+				margin-left: 0;
+				margin-right: 12px;
 			}
 			.d2l-questions-multiple-choice-group {
 				display: flex;
@@ -94,15 +103,27 @@ class D2lQuestionsMultipleChoicePresentational extends SkeletonMixin(LocalizeQue
 				margin-right: 0.3rem;
 				margin-top: -0.1rem;
 			}
+			:host([dir="rtl"]) .d2l-questions-multiple-choice-row d2l-questions-icons-radio-unchecked,
+			:host([dir="rtl"]) .d2l-questions-multiple-choice-row d2l-questions-icons-radio-checked {
+				margin-left: 0.3rem;
+				margin-right: 0;
+			}
 			.d2l-questions-multiple-choice-row d2l-icon {
 				flex: none;
 				margin-right: 0.3rem;
+			}
+			:host([dir="rtl"]) .d2l-questions-multiple-choice-row d2l-icon {
+				margin-left: 0.3rem;
+				margin-right: 0;
 			}
 			.d2l-questions-multiple-choice-incorrect-icon {
 				color: var(--d2l-color-cinnabar);
 			}
 			.d2l-questions-multiple-choice-correct-icon {
 				color: var(--d2l-color-olivine);
+			}
+			:host([dir="rtl"]) .d2l-questions-multiple-choice-correct-icon {
+				transform: scaleX(-1);
 			}
 			.d2l-questions-multiple-choice-without-icon {
 				flex: none;


### PR DESCRIPTION
[US139463](https://rally1.rallydev.com/#/?detail=/userstory/638165060411&fdp=true): [Consistent Evaluation][Quizzing][UI][Questions] Add RTL for current question types

- Added RTL support for multiple choice, multi-select
- Written response seemed like it didn't need any changes (See screenshots below)

#### Multiple Choice:

![image](https://user-images.githubusercontent.com/90270112/170127471-7b982efe-d66c-4790-9e01-5bbba5ae5f98.png)
![image](https://user-images.githubusercontent.com/90270112/170127512-e0041167-c5a3-4e20-addb-b5928a45b83b.png)

#### Multi-select:

![image](https://user-images.githubusercontent.com/90270112/170127547-97ed68be-ebb8-4723-8ecb-67ead8831bcd.png)

#### Written response:

![image](https://user-images.githubusercontent.com/90270112/170127579-f5619023-1d9d-4d89-8372-a0a5c5f8ffdf.png)
