### PR TITLE
feat: US138584 Manually making written response skeleton appear

### DIFF
--- a/components/d2l-questions-written-response.js
+++ b/components/d2l-questions-written-response.js
@@ -33,6 +33,11 @@ class D2lQuestionWrittenResponse extends SkeletonMixin(LitElement) {
 		`;
 	}
 
+	constructor() {
+		super();
+		this.skeleton = true;
+	}
+
 	render() {
 		return html`
 			<d2l-questions-written-response-presentational
@@ -50,11 +55,13 @@ class D2lQuestionWrittenResponse extends SkeletonMixin(LitElement) {
 	async updated(changedProperties) {
 		super.updated();
 		if (changedProperties.has('question') || changedProperties.has('questionResponse')) {
+			this.skeleton = true;
 			await this._loadQuestionData(changedProperties);
 		}
 	}
 
 	async _finishedLoadingQuestionData() {
+		this.skeleton = false;
 		this.dispatchEvent(new CustomEvent('d2l-questions-question-loaded', {
 			composed: true,
 			bubbles: true,


### PR DESCRIPTION
[US138584](https://rally1.rallydev.com/#/?detail=/userstory/632832032003&fdp=true): [Consistent Evaluation][Quizzing][UI][Questions] Add skeleton to written response

Main work done in: https://github.com/BrightspaceHypermediaComponents/questions/pull/92

This is my fault, when I tested the above PR I had changes in CE which handled making the written response skeleton appear.
But since we are holding off on the attempt-result skeleton, those changes did not get pushed in.

Written response's skeleton will now appear/disappear exactly as multiple choice does it for now.