### PR TITLE
Us130375/jtran add true false question type

### DIFF
--- a/components/d2l-questions-question.js
+++ b/components/d2l-questions-question.js
@@ -91,6 +91,8 @@ class D2lQuestionsQuestion extends SkeletonMixin((LitElement)) {
 				this._questionType = Classes.questions.multiSelect;
 			} else if (this._question.entity.hasClass(Classes.questions.longAnswer)) { // previous naming convention for "Written Response" is "Long Answer", API response displaying LongAnswer currently
 				this._questionType = Classes.questions.longAnswer;
+			} else if (this._question.entity.hasClass(Classes.questions.trueFalse)) {
+				this._questionType = Classes.questions.trueFalse;
 			}
 		}
 	}
@@ -127,6 +129,16 @@ class D2lQuestionsQuestion extends SkeletonMixin((LitElement)) {
 						.questionResponse=${this._questionResponse}
 						.token=${this.token}>
 					</d2l-questions-written-response>`;
+
+			case Classes.questions.trueFalse:
+				await import('./d2l-questions-true-false.js');
+				return html`
+					<d2l-questions-true-false
+						?readonly=${this.readonly}
+						.question=${this._question}
+						.questionResponse=${this._questionResponse}
+						.token=${this.token}>
+					</d2l-questions-true-false>`;
 
 			default:
 				throw 'Unknown question type';

--- a/components/d2l-questions-true-false-presentational.js
+++ b/components/d2l-questions-true-false-presentational.js
@@ -1,0 +1,232 @@
+import './icons/d2l-questions-icons-radio.js';
+import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/html-block/html-block.js';
+import '@brightspace-ui/core/components/icons/icon.js';
+import '@brightspace-ui/core/components/offscreen/offscreen.js';
+import { css, html, LitElement } from 'lit';
+import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
+import { LocalizeQuestions } from '../localize-questions.js';
+import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+
+class D2lQuestionsTrueFalsePresentational extends SkeletonMixin(RtlMixin(LocalizeQuestions(LitElement))) {
+
+	static get properties() {
+		return {
+			choices: { type: Array },
+			questionText: {
+				attribute: 'question-text',
+				type: String
+			},
+			readonly: { type: Boolean }
+		};
+	}
+
+	static get styles() {
+		return [super.styles, radioStyles, bodyCompactStyles, css`
+			:host {
+				display: inline-block;
+				width: 100%;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			:host([skeleton]) .d2l-questions-true-false-group {
+				display: flex;
+				flex-direction: column;
+			}
+			:host([skeleton]) .d2l-questions-true-false-question-text-skeleton {
+				height: 20px;
+				margin-bottom: 28px;
+				max-width: 603px;
+			}
+			.d2l-questions-true-false-row-skeleton {
+				align-items: flex-start;
+				color: var(--d2l-color-galena);
+				display: flex;
+				flex-wrap: nowrap;
+				height: 24px;
+				padding-bottom: 1.2rem;
+			}
+			:host([skeleton]) .d2l-input-radio-skeleton {
+				align-self: center;
+				height: 24px;
+				margin-left: 0;
+				width: 24px;
+			}
+			:host([skeleton]) .d2l-input-radio-skeleton-readonly {
+				align-self: center;
+				height: 18px;
+				margin-left: 26px;
+				width: 18px;
+			}
+			:host([skeleton][dir="rtl"]) .d2l-input-radio-skeleton-readonly {
+				margin-left: 0;
+				margin-right: 26px;
+			}
+			:host([skeleton]) .d2l-questions-html-block {
+				align-self: center;
+				height: 14px;
+				margin-left: 12px;
+				width: 134px;
+			}
+			:host([skeleton][dir="rtl"]) .d2l-questions-html-block {
+				margin-left: 0;
+				margin-right: 12px;
+			}
+			.d2l-questions-true-false-group {
+				display: flex;
+				flex-direction: column;
+			}
+			.d2l-questions-true-false-question-text {
+				padding-bottom: 1rem;
+			}
+			.d2l-questions-true-false-row {
+				align-items: flex-start;
+				color: var(--d2l-color-galena);
+				display: flex;
+				flex-wrap: nowrap;
+				padding-bottom: 1.2rem;
+			}
+			.d2l-input-radio-label {
+				align-items: flex-start;
+				color: var(--d2l-color-galena);
+				display: flex;
+				flex-wrap: nowrap;
+			}
+			.d2l-questions-true-false-row d2l-questions-icons-radio-unchecked,
+			.d2l-questions-true-false-row d2l-questions-icons-radio-checked {
+				flex: none;
+				margin-right: 0.3rem;
+				margin-top: -0.1rem;
+			}
+			:host([dir="rtl"]) .d2l-questions-true-false-row d2l-questions-icons-radio-unchecked,
+			:host([dir="rtl"]) .d2l-questions-true-false-row d2l-questions-icons-radio-checked {
+				margin-left: 0.3rem;
+				margin-right: 0;
+			}
+			.d2l-questions-true-false-row d2l-icon {
+				flex: none;
+				margin-right: 0.3rem;
+			}
+			:host([dir="rtl"]) .d2l-questions-true-false-row d2l-icon {
+				margin-left: 0.3rem;
+				margin-right: 0;
+			}
+			.d2l-questions-true-false-incorrect-icon {
+				color: var(--d2l-color-cinnabar);
+			}
+			.d2l-questions-true-false-correct-icon {
+				color: var(--d2l-color-olivine);
+			}
+			:host([dir="rtl"]) .d2l-questions-true-false-correct-icon {
+				transform: scaleX(-1);
+			}
+			.d2l-questions-true-false-without-icon {
+				flex: none;
+				width: 1.2rem;
+			}
+		`];
+	}
+
+	constructor() {
+		super();
+		this.radioGroupId = getUniqueId();
+	}
+
+	render() {
+		if (this.choices !== undefined && !this.skeleton) {
+			return html`
+				<div class="d2l-questions-true-false-question-text">
+					<d2l-html-block>
+						${unsafeHTML(this.questionText)}
+					</d2l-html-block>
+				</div>
+
+				<div class="d2l-questions-true-false-group">
+					${this.choices.map((choice) => this._renderChoice(choice))}
+				</div>
+			`;
+		} else {
+			return this._renderTrueFalseSkeleton();
+		}
+	}
+
+	_renderChoice(choice) {
+		if (this.readonly) {
+			return this._renderReadonlyChoice(choice);
+		} else {
+			return html`
+				<div class="d2l-questions-true-false-row">
+					<label class="d2l-input-radio-label">
+						<input type="radio" name="${this.radioGroupId}"
+						?checked=${choice.selected}
+						aria-label="${choice.text}">
+						<d2l-html-block>
+							${unsafeHTML(choice.htmlText)}
+						</d2l-html-block>
+					</label>
+				</div>
+			`;
+		}
+	}
+
+	_renderReadonlyChoice(choice) {
+		let icon = undefined;
+		let lang = '';
+		let iconStyle = '';
+		if (choice.selected && choice.correct) {
+			icon = 'check';
+			lang = 'correctResponse';
+		} else if (choice.selected && !choice.correct) {
+			icon = 'close-large-thick';
+			lang = 'incorrectResponse';
+			iconStyle = 'd2l-questions-true-false-incorrect-icon';
+		} else if (!choice.selected && choice.correct) {
+			icon = 'arrow-thin-right';
+			lang = 'correctAnswer';
+			iconStyle = 'd2l-questions-true-false-correct-icon';
+		}
+
+		return html`
+			<div class="d2l-questions-true-false-row d2l-body-compact">
+				${icon ? html`<d2l-icon icon="tier1:${icon}" class="${iconStyle}"></d2l-icon>` : html`<div class="d2l-questions-true-false-without-icon"></div>`}
+				${choice.selected ? html`<d2l-questions-icons-radio-checked></d2l-questions-icons-radio-checked>` : html`<d2l-questions-icons-radio-unchecked></d2l-questions-icons-radio-unchecked>`}
+				<d2l-offscreen>${this.localize(lang)}${choice.text}</d2l-offscreen>
+				<d2l-html-block aria-hidden="true">
+					${unsafeHTML(choice.htmlText)}
+				</d2l-html-block>
+			</div>`;
+	}
+
+	_renderTrueFalseSkeleton() {
+		const skeletonChoices = [1, 2];
+		/* eslint-disable indent */
+		return html`
+			<div class="d2l-skeletize d2l-questions-true-false-question-text-skeleton"></div>
+			<div class="d2l-questions-true-false-group">
+				${skeletonChoices.map(() => {
+					if (this.readonly) {
+						return html`
+							<div class="d2l-questions-true-false-row-skeleton">
+								<div class="d2l-input-radio-skeleton-readonly d2l-skeletize"></div>
+								<div class="d2l-questions-html-block d2l-skeletize"></div>
+							</div>
+						`;
+					} else {
+						return html`
+							<div class="d2l-questions-true-false-row">
+								<div class="d2l-input-radio-skeleton d2l-skeletize"></div>
+								<div class="d2l-questions-html-block d2l-skeletize"></div>
+							</div>
+						`;
+					}})}
+			</div>
+		`;
+		/* eslint-enable indent */
+	}
+}
+customElements.define('d2l-questions-true-false-presentational', D2lQuestionsTrueFalsePresentational);

--- a/components/d2l-questions-true-false.js
+++ b/components/d2l-questions-true-false.js
@@ -1,0 +1,133 @@
+import './d2l-questions-true-false-presentational.js';
+import 'd2l-polymer-siren-behaviors/store/entity-store.js';
+import { Classes, Rels } from 'd2l-hypermedia-constants';
+import { css, html, LitElement } from 'lit';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+
+class D2lQuestionsTrueFalse extends SkeletonMixin(LitElement) {
+
+	static get properties() {
+		return {
+			readonly: { type: Boolean },
+			question: { type: Object },
+			questionResponse: { type: Object },
+			token: { type: Object },
+			_choices: { type: Array },
+			_questionTextHTML: { type: String }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: inline-block;
+				width: 100%;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+		`;
+	}
+
+	constructor() {
+		super();
+		this._choices = [];
+		this.skeleton = true;
+	}
+
+	render() {
+		return html`
+			<d2l-questions-true-false-presentational
+				?readonly=${this.readonly}
+				question-text=${this._questionTextHTML}
+				.choices=${this._choices}
+				?skeleton=${this.skeleton}>
+			</d2l-questions-true-false-presentational>`;
+	}
+
+	async updated(changedProperties) {
+		super.updated();
+		if ((changedProperties.has('question') || changedProperties.has('questionResponse'))) {
+			this.skeleton = true;
+			await this._loadQuestionData();
+		}
+	}
+
+	async _finishedLoadingQuestionData() {
+		this.skeleton = false;
+		this.dispatchEvent(new CustomEvent('d2l-questions-question-loaded', {
+			composed: true,
+			bubbles: true,
+		}));
+	}
+
+	async _getEntityFromHref(targetHref, bypassCache) {
+		return await window.D2L.Siren.EntityStore.fetch(targetHref, this.token, bypassCache);
+	}
+
+	async _loadChoices() {
+		// Reponse has the choices more readily available than the actual question does + the answer/correctness states
+		if (this.questionResponse) {
+			return await this._loadChoicesFromResponse();
+		}
+		const itemBodyHref = this.question.entity.getSubEntityByRel(Rels.Questions.itemBody);
+		const itemBodyEntity = await this._getEntityFromHref(itemBodyHref);
+		const interactionHref = itemBodyEntity.entity.getSubEntityByRel(Rels.Questions.interaction);
+		const interactionEntity = await this._getEntityFromHref(interactionHref);
+		const choices = await Promise.all(interactionEntity.entity.getSubEntitiesByClass(Classes.questions.simpleChoice).map(async choice => {
+			const choiceEntity = await this._getEntityFromHref(choice.href, false);
+			return {
+				href: choice.href,
+				htmlText: choiceEntity.entity.getSubEntityByClass(Classes.text.richtext).properties.html,
+				text: choiceEntity.entity.getSubEntityByClass(Classes.text.richtext).properties.text,
+			};
+		}));
+		this._choices = choices === undefined ? [] : choices;
+	}
+
+	async _loadChoicesFromResponse() {
+		let hasCorrectAnswer = false;
+		const candidateResponse = this.questionResponse.entity.getSubEntityByClass(Classes.questions.candidateResponse);
+		const choices = await Promise.all(candidateResponse.entities.map(async choice => {
+			if (choice.hasClass(Classes.questions.correctResponse)) {
+				hasCorrectAnswer = true;
+			}
+			const choiceHref = choice.getLinkByRel(Rels.Questions.identifier).href;
+			const choiceEntity = await this._getEntityFromHref(choiceHref, false);
+			return {
+				htmlText: choiceEntity.entity.getSubEntityByClass(Classes.text.richtext).properties.html,
+				text: choiceEntity.entity.getSubEntityByClass(Classes.text.richtext).properties.text,
+				selected: choice.hasClass(Classes.questions.selected),
+				correct: choice.hasClass(Classes.questions.correctResponse),
+				href: choiceHref
+			};
+		}));
+		if (!hasCorrectAnswer) {
+			const responseHref = candidateResponse.getLinkByRel(Rels.Questions.responseDeclaration).href;
+			const response = await this._getEntityFromHref(responseHref, false);
+			const correctResponse = response.entity.getSubEntityByClass(Classes.questions.correctResponse);
+			const correctChoiceHref = correctResponse.getSubEntityByClass(Classes.questions.value).getLinkByRel(Rels.Questions.identifier).href;
+			choices.find(choice => choice.href === correctChoiceHref).correct = true;
+		}
+		this._choices = choices === undefined ? [] : choices;
+		return;
+	}
+
+	async _loadQuestionData() {
+		try {
+			const questionTextEntity = this.question.entity.getSubEntityByClass(Classes.questions.questionText);
+			this._questionTextHTML = questionTextEntity.properties.html;
+		} catch (err) {
+			console.error(err);
+			throw new Error('d2l-questions-true-false: Unable to get question text from question');
+		}
+		try {
+			await this._loadChoices();
+		} catch (err) {
+			console.error(err);
+			throw new Error('d2l-questions-true-false: Unable to load choices from question');
+		}
+		await this._finishedLoadingQuestionData();
+	}
+}
+customElements.define('d2l-questions-true-false', D2lQuestionsTrueFalse);

--- a/demo/data/true-false/choice-interaction.json
+++ b/demo/data/true-false/choice-interaction.json
@@ -1,0 +1,62 @@
+{
+  "class": [
+    "choice-interaction",
+    "shuffle"
+  ],
+  "properties": {
+    "maxChoices": 1,
+    "enumerationType": "None"
+  },
+  "entities": [
+    {
+      "class": [
+        "richtext"
+      ],
+      "rel": [
+        "https://questions.api.brightspace.com/rels/prompt"
+      ],
+      "properties": {
+        "text": "Mark the item that is true.",
+        "html": "Mark the item that is true."
+      }
+    },
+    {
+      "class": [
+        "simple-choice"
+      ],
+      "rel": [
+        "item"
+      ],
+      "href": "./data/true-false/simple-choice-1.json"
+    },
+    {
+      "class": [
+        "simple-choice"
+      ],
+      "rel": [
+        "item"
+      ],
+      "href": "./data/true-false/simple-choice-2.json"
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/item-body"
+      ],
+      "href": "./data/true-false/item-body.json"
+    },
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "#"
+    },
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/response-declaration"
+      ],
+      "href": "./data/true-false/response-declaration.json"
+    }
+  ]
+}

--- a/demo/data/true-false/item-body.json
+++ b/demo/data/true-false/item-body.json
@@ -1,0 +1,24 @@
+{
+  "class": [
+    "item-body"
+  ],
+  "entities": [
+    {
+      "class": [
+        "choice-interaction"
+      ],
+      "rel": [
+        "https://questions.api.brightspace.com/rels/interaction"
+      ],
+      "href": "./data/true-false/choice-interaction.json"
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/question"
+      ],
+      "href": "./data/true-false/question.json"
+    }
+  ]
+}

--- a/demo/data/true-false/question-response-correct.json
+++ b/demo/data/true-false/question-response-correct.json
@@ -1,0 +1,80 @@
+{
+  "class": [
+    "question-response"
+  ],
+  "properties": {
+    "savedTime": "2011-01-11T12:05:00.000Z"
+  },
+  "entities": [
+    {
+      "class": [
+        "candidate-response"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "baseType": "identifier",
+        "cardinality": "single"
+      },
+      "entities": [
+        {
+          "class": [
+            "value",
+            "selected",
+            "correct-response"
+          ],
+          "rel": [
+            "item"
+          ],
+          "links": [
+            {
+              "rel": [
+                "https://questions.api.brightspace.com/rels/identifier"
+              ],
+              "href": "./data/true-false/simple-choice-1.json"
+            }
+          ]
+        },
+        {
+          "class": [
+            "value"
+          ],
+          "rel": [
+            "item"
+          ],
+          "links": [
+            {
+              "rel": [
+                "https://questions.api.brightspace.com/rels/identifier"
+              ],
+              "href": "./data/true-false/simple-choice-2.json"
+            }
+          ]
+        }
+      ],
+      "links": [
+        {
+          "rel": [
+            "https://questions.api.brightspace.com/rels/interaction"
+          ],
+          "href": "./data/true-false/choice-interaction.json"
+        },
+        {
+          "rel": [
+            "https://questions.api.brightspace.com/rels/response-declaration"
+          ],
+          "href": "./data/true-false/response-declaration.json"
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "#"
+    }
+  ]
+}

--- a/demo/data/true-false/question-response-incorrect.json
+++ b/demo/data/true-false/question-response-incorrect.json
@@ -1,0 +1,80 @@
+{
+  "class": [
+    "question-response"
+  ],
+  "properties": {
+    "savedTime": "2011-01-11T12:05:00.000Z"
+  },
+  "entities": [
+    {
+      "class": [
+        "candidate-response"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "baseType": "identifier",
+        "cardinality": "single"
+      },
+      "entities": [
+        {
+          "class": [
+            "value"
+          ],
+          "rel": [
+            "item"
+          ],
+          "links": [
+            {
+              "rel": [
+                "https://questions.api.brightspace.com/rels/identifier"
+              ],
+              "href": "./data/true-false/simple-choice-1.json"
+            }
+          ]
+        },
+        {
+          "class": [
+            "value",
+            "selected",
+            "incorrect-response"
+          ],
+          "rel": [
+            "item"
+          ],
+          "links": [
+            {
+              "rel": [
+                "https://questions.api.brightspace.com/rels/identifier"
+              ],
+              "href": "./data/true-false/simple-choice-2.json"
+            }
+          ]
+        }
+      ],
+      "links": [
+        {
+          "rel": [
+            "https://questions.api.brightspace.com/rels/interaction"
+          ],
+          "href": "./data/true-false/choice-interaction.json"
+        },
+        {
+          "rel": [
+            "https://questions.api.brightspace.com/rels/response-declaration"
+          ],
+          "href": "./data/true-false/response-declaration.json"
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "#"
+    }
+  ]
+}

--- a/demo/data/true-false/question.json
+++ b/demo/data/true-false/question.json
@@ -1,0 +1,37 @@
+{
+  "class": [
+    "named-entity",
+    "TrueFalse"
+  ],
+  "properties": {
+    "name": "True False Question 1",
+    "type": 2,
+    "typeText": "true-false"
+  },
+  "entities": [
+    {
+      "class": [
+        "richtext",
+        "questionText"
+      ],
+      "rel": [
+        "item",
+        "https://questions.api.brightspace.com/rels/questionText",
+        "https://questions.api.brightspace.com/rels/title"
+      ],
+      "properties": {
+        "text": "Mark the item that is True.",
+        "html": "<p>Mark the item that is <em>True</em>.</p>"
+      }
+    },
+    {
+      "class": [
+        "item-body"
+      ],
+      "rel": [
+        "https://questions.api.brightspace.com/rels/item-body"
+      ],
+      "href": "./data/true-false/item-body.json"
+    }
+  ]
+}

--- a/demo/data/true-false/response-declaration.json
+++ b/demo/data/true-false/response-declaration.json
@@ -1,0 +1,57 @@
+{
+  "class": [
+    "response-declaration"
+  ],
+  "properties": {
+    "cardinality": "single",
+    "baseType": "identifier"
+  },
+  "entities": [
+    {
+      "class": [
+        "correct-response"
+      ],
+      "rel": [
+        "item"
+      ],
+      "entities": [
+        {
+          "class": [
+            "value"
+          ],
+          "rel": [
+            "item"
+          ],
+          "links": [
+            {
+              "rel": [
+                "https://questions.api.brightspace.com/rels/identifier"
+              ],
+              "href": "./data/true-false/simple-choice-1.json"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/item-body"
+      ],
+      "href": "#not-included-in-demo-data"
+    },
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/interaction"
+      ],
+      "href": "#not-included-in-demo-data"
+    },
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "#"
+    }
+  ]
+}

--- a/demo/data/true-false/simple-choice-1.json
+++ b/demo/data/true-false/simple-choice-1.json
@@ -1,0 +1,33 @@
+{
+  "class": [
+    "simple-choice"
+  ],
+  "entities": [
+    {
+      "class": [
+        "richtext"
+      ],
+      "rel": [
+        "https://questions.api.brightspace.com/rels/text"
+      ],
+      "properties": {
+        "text": "True",
+        "html": "True"
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/interaction"
+      ],
+      "href": "#not-included-in-demo-data"
+    },
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "#"
+    }
+  ]
+}

--- a/demo/data/true-false/simple-choice-2.json
+++ b/demo/data/true-false/simple-choice-2.json
@@ -1,0 +1,33 @@
+{
+  "class": [
+    "simple-choice"
+  ],
+  "entities": [
+    {
+      "class": [
+        "richtext"
+      ],
+      "rel": [
+        "https://questions.api.brightspace.com/rels/text"
+      ],
+      "properties": {
+        "text": "False",
+        "html": "False"
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/interaction"
+      ],
+      "href": "#not-included-in-demo-data"
+    },
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "#"
+    }
+  ]
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,6 +12,9 @@
 			<li>
 				<a href="./written-response.html">written-response</a>
 			</li>
+			<li>
+				<a href="./true-false.html">true-false</a>
+			</li>
 		</ul>
 	</body>
 </html>

--- a/demo/true-false.html
+++ b/demo/true-false.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script type="module">
+			import '@brightspace-ui/core/components/demo/demo-page.js';
+			import '../components/d2l-questions-question.js';
+		</script>
+		<title>D2lQuestionsQuestion true-false</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta charset="UTF-8">
+	</head>
+	<body>
+		<d2l-demo-page page-title="D2l Questions - Given true-false">
+			<h2>Answerable - Correct</h2>
+			<d2l-demo-snippet>
+				<d2l-questions-question
+					question-href="./data/true-false/question.json"
+					question-response-href="./data/true-false/question-response-correct.json"
+					token="token"></d2l-questions-question>
+			</d2l-demo-snippet>
+			<h2>Answerable - No Response</h2>
+			<d2l-demo-snippet>
+				<d2l-questions-question
+					question-href="./data/true-false/question.json"
+					token="token"></d2l-questions-question>
+			</d2l-demo-snippet>
+			<h2>Readonly - No Response</h2>
+			<d2l-demo-snippet>
+				<d2l-questions-question
+					readonly
+					question-href="./data/true-false/question.json"
+					token="token"></d2l-questions-question>
+			</d2l-demo-snippet>
+			<h2>ReadOnly - Correct</h2>
+			<d2l-demo-snippet>
+				<d2l-questions-question
+					readonly
+					question-href="./data/true-false/question.json"
+					question-response-href="./data/true-false/question-response-correct.json"
+					token="token"></d2l-questions-question>
+			</d2l-demo-snippet>
+			<h2>ReadOnly - Incorrect</h2>
+			<d2l-demo-snippet>
+				<d2l-questions-question
+					readonly
+					question-href="./data/true-false/question.json"
+					question-response-href="./data/true-false/question-response-incorrect.json"
+					token="token"></d2l-questions-question>
+			</d2l-demo-snippet>
+
+		</d2l-demo-page>
+	</body>
+</html>

--- a/test/d2l-questions-true-false-presentational-data.js
+++ b/test/d2l-questions-true-false-presentational-data.js
@@ -1,0 +1,36 @@
+export const choicesUnanswered = [
+	{
+		htmlText: 'True',
+		text: 'True'
+	},
+	{
+		htmlText: 'False',
+		text: 'False'
+	}
+];
+
+export const choicesCorrect = [
+	{
+		htmlText: 'True',
+		text: 'True',
+		selected: true,
+		correct: true
+	},
+	{
+		htmlText: 'False',
+		text: 'False'
+	}
+];
+
+export const choicesIncorrect = [
+	{
+		htmlText: 'True',
+		text: 'True'
+	},
+	{
+		htmlText: 'False',
+		text: 'False',
+		selected: true,
+		correct: false
+	}
+];

--- a/test/d2l-questions-true-false.test
+++ b/test/d2l-questions-true-false.test
@@ -1,0 +1,184 @@
+import '../components/d2l-questions-true-false.js';
+import { Classes, Rels } from 'd2l-hypermedia-constants';
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+import { stub } from 'sinon';
+
+describe('d2l-questions-true-false', () => {
+
+	// _loadChoices mocks
+	const CHOICE_HREF = 'choiceHref';
+	const CHOICE_HTML = '<p>Sample Option</p>';
+	const CHOICE_TEXT = 'Sample Option';
+	const CHOICES = [
+		{
+			href: CHOICE_HREF,
+			htmlText: CHOICE_HTML,
+			text: CHOICE_TEXT
+		},
+		{
+			href: CHOICE_HREF,
+			htmlText: CHOICE_HTML,
+			text: CHOICE_TEXT
+		}
+	];
+	const CHOICE_ENTITY = {
+		entity: {
+			getSubEntityByClass: function(entityClass) {
+				return entityClass === Classes.text.richtext ? {
+					properties: {
+						html: CHOICE_HTML,
+						text: CHOICE_TEXT
+					}
+				} : undefined;
+			}
+		}
+	};
+	const INTERACTION_HREF = 'interactionHref';
+	const INTERACTION_ENTITY = {
+		entity: {
+			getSubEntitiesByClass: function(entityClass) {
+				return entityClass === Classes.questions.simpleChoice ? [
+					{ href: CHOICE_HREF },
+					{ href: CHOICE_HREF }
+				] : undefined;
+			}
+		}
+	};
+	const ITEM_BODY_HREF = 'itemBodyHref';
+	const ITEM_BODY_ENTITY = {
+		entity: {
+			getSubEntityByRel: function(entityRel) {
+				return entityRel === Rels.Questions.interaction ? INTERACTION_HREF : undefined;
+			}
+		}
+	};
+	const QUESTION_TEXT = '<p>Sample Text</p>';
+	const QUESTION_ENTITY = {
+		entity: {
+			getSubEntityByClass: function(entityClass) {
+				return entityClass === Classes.questions.questionText ? {
+					properties: {
+						html: QUESTION_TEXT
+					}
+				} : undefined;
+			},
+			getSubEntityByRel: function(entityRel) {
+				return entityRel === Rels.Questions.itemBody ? ITEM_BODY_HREF : undefined;
+			}
+		}
+	};
+
+	// _loadChoicesFromResponse mocks
+	const CHOICES_RESPONSE = [
+		{
+			htmlText: CHOICE_HTML,
+			text: CHOICE_TEXT,
+			selected: true,
+			correct: true,
+			href: CHOICE_HREF
+		},
+		{
+			htmlText: CHOICE_HTML,
+			text: CHOICE_TEXT,
+			selected: false,
+			correct: false,
+			href: CHOICE_HREF
+		}
+	];
+	const CHOICE_RESPONSE = {
+		getLinkByRel: function(rel) {
+			return rel === Rels.Questions.identifier ? {
+				href: CHOICE_HREF
+			} : undefined;
+		},
+		hasClass: function(className) {
+			return this.class.includes(className);
+		},
+		class: [Classes.questions.value]
+	};
+	const CHOICE_RESPONSE_CORRECT_SELECTED = {
+		getLinkByRel: function(rel) {
+			return rel === Rels.Questions.identifier ? {
+				href: CHOICE_HREF
+			} : undefined;
+		},
+		hasClass: function(className) {
+			return this.class.includes(className);
+		},
+		class: [Classes.questions.value, Classes.questions.correctResponse, Classes.questions.selected]
+	};
+	const CANDIDATE_RESPONSE_ENTITY = {
+		entities: [CHOICE_RESPONSE_CORRECT_SELECTED, CHOICE_RESPONSE]
+	};
+	const QUESTION_RESPONSE_ENTITY = {
+		entity: {
+			getSubEntityByClass: function(entityClass) {
+				return entityClass === Classes.questions.candidateResponse ? CANDIDATE_RESPONSE_ENTITY : undefined;
+			}
+		}
+	};
+
+	function stubGetEntityFromHref(targetHref) {
+		switch (targetHref) {
+			case ITEM_BODY_HREF:
+				return ITEM_BODY_ENTITY;
+			case INTERACTION_HREF:
+				return INTERACTION_ENTITY;
+			case CHOICE_HREF:
+				return CHOICE_ENTITY;
+			default:
+				throw 'unexpected href requested';
+		}
+	}
+
+	it('should construct', () => {
+		runConstructor('d2l-questions-true-false');
+	});
+
+	it('should load question text', async() => {
+		const elem = await fixture(html` <d2l-questions-true-false></d2l-questions-true-false> `);
+		stub(elem, '_loadChoices').callsFake(() => { elem._choices = [];});
+		elem.question = QUESTION_ENTITY;
+		await elementUpdated(elem);
+		expect(elem._questionTextHTML).to.equal(QUESTION_TEXT);
+	});
+
+	it('should load options for question', async() => {
+		const elem = await fixture(html` <d2l-questions-true-false></d2l-questions-true-false> `);
+		stub(elem, '_getEntityFromHref').callsFake(stubGetEntityFromHref);
+		elem.question = QUESTION_ENTITY;
+		await elementUpdated(elem);
+		elem.addEventListener('d2l-questions-question-loaded', async() => {
+			expect(elem._choices).to.deep.equal(CHOICES);
+		});
+	});
+
+	it('should reload when question changes', async() => {
+		const elem = await fixture(html` <d2l-questions-true-false></d2l-questions-true-false> `);
+		const _loadQuestionDataStub = stub(elem, '_loadQuestionData');
+		elem.question = QUESTION_ENTITY;
+		await elementUpdated(elem);
+		expect(_loadQuestionDataStub).to.have.callCount(1);
+	});
+
+	it('should load options from question response', async() => {
+		const elem = await fixture(html` <d2l-questions-true-false></d2l-questions-true-false> `);
+		stub(elem, '_getEntityFromHref').callsFake(stubGetEntityFromHref);
+		elem.questionResponse = QUESTION_RESPONSE_ENTITY;
+		elem.question = QUESTION_ENTITY;
+		await elementUpdated(elem);
+		elem.addEventListener('d2l-questions-question-loaded', async() => {
+			expect(elem._choices).to.deep.equal(CHOICES_RESPONSE);
+		});
+	});
+
+	it('should reload when question response changes', async() => {
+		const elem = await fixture(html` <d2l-questions-true-false></d2l-questions-true-false> `);
+		const _loadQuestionDataStub = stub(elem, '_loadQuestionData');
+		elem.questionResponse = QUESTION_RESPONSE_ENTITY;
+		await elementUpdated(elem);
+		expect(_loadQuestionDataStub).to.have.callCount(1);
+	});
+
+});

--- a/test/d2l-questions-true-false.visual-diff.html
+++ b/test/d2l-questions-true-false.visual-diff.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>d2l-questions-true-false visual-diff tests</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta charset="UTF-8">
+		<style>
+			html {
+				font-size: 20px;
+			}
+			div {
+				display: flex;
+				margin: 10px;
+				width: 200px;
+			}
+		</style>
+		<script type="module">
+			import '@brightspace-ui/core/components/typography/typography.js';
+			import '../components/d2l-questions-true-false-presentational.js';
+			import { choicesCorrect, choicesIncorrect, choicesUnanswered } from './d2l-questions-true-false-presentational-data.js';
+
+			const answered = document.getElementById('answered');
+			answered.choices = choicesCorrect;
+			const unanswered = document.getElementById('unanswered');
+			unanswered.choices = choicesUnanswered;
+
+			const readonlyUnanswered = document.getElementById('readonly-unanswered');
+			readonlyUnanswered.choices = choicesUnanswered;
+			const readonlyCorrect = document.getElementById('readonly-correct');
+			readonlyCorrect.choices = choicesCorrect;
+			const readonlyIncorrect = document.getElementById('readonly-incorrect');
+			readonlyIncorrect.choices = choicesIncorrect;
+
+		</script>
+	</head>
+	<body class="d2l-typography">
+		<div id="true-false">
+			<d2l-questions-true-false-presentational id="answered"
+				question-text="<p>Mark the item that is <i>True.</i></p>">
+			</d2l-questions-true-false-presentational>
+		</div>
+		<div id="true-false-unanswered">
+			<d2l-questions-true-false-presentational id="unanswered"
+				question-text="<p>Mark the item that is <i>True.</i></p>">
+			</d2l-questions-true-false-presentational>
+		</div>
+		<div id="true-false-readonly">
+			<d2l-questions-true-false-presentational id="readonly-unanswered"
+				readonly
+				question-text="<p>Mark the item that is <i>True.</i></p>">
+			</d2l-questions-true-false-presentational>
+		</div>
+		<div id="true-false-readonly-correct">
+			<d2l-questions-true-false-presentational  id="readonly-correct"
+				readonly
+				question-text="<p>Mark the item that is <i>True.</i></p>">
+			</d2l-questions-true-false-presentational>
+		</div>
+		<div id="true-false-readonly-incorrect">
+			<d2l-questions-true-false-presentational id="readonly-incorrect"
+				readonly
+				question-text="<p>Mark the item that is <i>True.</i></p>">
+			</d2l-questions-true-false-presentational>
+		</div>
+		<div id="true-false-skeleton">
+			<d2l-questions-true-false-presentational
+				skeleton>
+			</d2l-questions-true-false-presentational>
+		</div>
+		<div id="true-false-skeleton-readonly">
+			<d2l-questions-true-false-presentational
+				readonly
+				skeleton>
+			</d2l-questions-true-false-presentational>
+		</div>
+	</body>
+</html>

--- a/test/d2l-questions-true-false.visual-diff.js
+++ b/test/d2l-questions-true-false.visual-diff.js
@@ -1,0 +1,59 @@
+import puppeteer from 'puppeteer';
+import { VisualDiff } from '@brightspace-ui/visual-diff';
+
+describe('d2l-questions-true-false', () => {
+
+	const visualDiff = new VisualDiff('d2l-questions-true-false', import.meta.url);
+
+	let browser, page;
+
+	before(async() => {
+		browser = await puppeteer.launch();
+		page = await visualDiff.createPage(browser);
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-questions-true-false.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
+		await page.bringToFront();
+	});
+
+	beforeEach(async() => {
+		await visualDiff.resetFocus(page);
+	});
+
+	after(async() => await browser.close());
+
+	describe('true-false', () => {
+		it('default', async function() {
+			const rect = await visualDiff.getRect(page, '#true-false');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+
+		it('unanswered', async function() {
+			const rect = await visualDiff.getRect(page, '#true-false-unanswered');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+
+		it('readonly', async function() {
+			const rect = await visualDiff.getRect(page, '#true-false-readonly');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+
+		it('readonly-correct', async function() {
+			const rect = await visualDiff.getRect(page, '#true-false-readonly-correct');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+
+		it('readonly-incorrect', async function() {
+			const rect = await visualDiff.getRect(page, '#true-false-readonly-incorrect');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+
+		it('skeleton-default', async function() {
+			const rect = await visualDiff.getRect(page, '#true-false-skeleton');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+
+		it('skeleton-readonly', async function() {
+			const rect = await visualDiff.getRect(page, '#true-false-skeleton-readonly');
+			await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+		});
+	});
+});

--- a/test/data/true-false/choice-interaction.json
+++ b/test/data/true-false/choice-interaction.json
@@ -1,0 +1,62 @@
+{
+  "class": [
+    "choice-interaction",
+    "shuffle"
+  ],
+  "properties": {
+    "maxChoices": 1,
+    "enumerationType": "None"
+  },
+  "entities": [
+    {
+      "class": [
+        "richtext"
+      ],
+      "rel": [
+        "https://questions.api.brightspace.com/rels/prompt"
+      ],
+      "properties": {
+        "text": "Mark the item that is true.",
+        "html": "Mark the item that is true."
+      }
+    },
+    {
+      "class": [
+        "simple-choice"
+      ],
+      "rel": [
+        "item"
+      ],
+      "href": "./data/true-false/simple-choice-1.json"
+    },
+    {
+      "class": [
+        "simple-choice"
+      ],
+      "rel": [
+        "item"
+      ],
+      "href": "./data/true-false/simple-choice-2.json"
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/item-body"
+      ],
+      "href": "./data/true-false/item-body.json"
+    },
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "#"
+    },
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/response-declaration"
+      ],
+      "href": "./data/true-false/response-declaration.json"
+    }
+  ]
+}

--- a/test/data/true-false/item-body.json
+++ b/test/data/true-false/item-body.json
@@ -1,0 +1,24 @@
+{
+  "class": [
+    "item-body"
+  ],
+  "entities": [
+    {
+      "class": [
+        "choice-interaction"
+      ],
+      "rel": [
+        "https://questions.api.brightspace.com/rels/interaction"
+      ],
+      "href": "./data/true-false/choice-interaction.json"
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/question"
+      ],
+      "href": "./data/true-false/question.json"
+    }
+  ]
+}

--- a/test/data/true-false/question-response-correct.json
+++ b/test/data/true-false/question-response-correct.json
@@ -1,0 +1,80 @@
+{
+  "class": [
+    "question-response"
+  ],
+  "properties": {
+    "savedTime": "2011-01-11T12:05:00.000Z"
+  },
+  "entities": [
+    {
+      "class": [
+        "candidate-response"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "baseType": "identifier",
+        "cardinality": "single"
+      },
+      "entities": [
+        {
+          "class": [
+            "value",
+            "selected",
+            "correct-response"
+          ],
+          "rel": [
+            "item"
+          ],
+          "links": [
+            {
+              "rel": [
+                "https://questions.api.brightspace.com/rels/identifier"
+              ],
+              "href": "./data/true-false/simple-choice-1.json"
+            }
+          ]
+        },
+        {
+          "class": [
+            "value"
+          ],
+          "rel": [
+            "item"
+          ],
+          "links": [
+            {
+              "rel": [
+                "https://questions.api.brightspace.com/rels/identifier"
+              ],
+              "href": "./data/true-false/simple-choice-2.json"
+            }
+          ]
+        }
+      ],
+      "links": [
+        {
+          "rel": [
+            "https://questions.api.brightspace.com/rels/interaction"
+          ],
+          "href": "./data/true-false/choice-interaction.json"
+        },
+        {
+          "rel": [
+            "https://questions.api.brightspace.com/rels/response-declaration"
+          ],
+          "href": "./data/true-false/response-declaration.json"
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "#"
+    }
+  ]
+}

--- a/test/data/true-false/question-response-incorrect.json
+++ b/test/data/true-false/question-response-incorrect.json
@@ -1,0 +1,80 @@
+{
+  "class": [
+    "question-response"
+  ],
+  "properties": {
+    "savedTime": "2011-01-11T12:05:00.000Z"
+  },
+  "entities": [
+    {
+      "class": [
+        "candidate-response"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "baseType": "identifier",
+        "cardinality": "single"
+      },
+      "entities": [
+        {
+          "class": [
+            "value"
+          ],
+          "rel": [
+            "item"
+          ],
+          "links": [
+            {
+              "rel": [
+                "https://questions.api.brightspace.com/rels/identifier"
+              ],
+              "href": "./data/true-false/simple-choice-1.json"
+            }
+          ]
+        },
+        {
+          "class": [
+            "value",
+            "selected",
+            "incorrect-response"
+          ],
+          "rel": [
+            "item"
+          ],
+          "links": [
+            {
+              "rel": [
+                "https://questions.api.brightspace.com/rels/identifier"
+              ],
+              "href": "./data/true-false/simple-choice-2.json"
+            }
+          ]
+        }
+      ],
+      "links": [
+        {
+          "rel": [
+            "https://questions.api.brightspace.com/rels/interaction"
+          ],
+          "href": "./data/true-false/choice-interaction.json"
+        },
+        {
+          "rel": [
+            "https://questions.api.brightspace.com/rels/response-declaration"
+          ],
+          "href": "./data/true-false/response-declaration.json"
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "#"
+    }
+  ]
+}

--- a/test/data/true-false/question.json
+++ b/test/data/true-false/question.json
@@ -1,0 +1,37 @@
+{
+  "class": [
+    "named-entity",
+    "TrueFalse"
+  ],
+  "properties": {
+    "name": "True False Question 1",
+    "type": 2,
+    "typeText": "true-false"
+  },
+  "entities": [
+    {
+      "class": [
+        "richtext",
+        "questionText"
+      ],
+      "rel": [
+        "item",
+        "https://questions.api.brightspace.com/rels/questionText",
+        "https://questions.api.brightspace.com/rels/title"
+      ],
+      "properties": {
+        "text": "Mark the item that is True.",
+        "html": "<p>Mark the item that is <em>True</em>.</p>"
+      }
+    },
+    {
+      "class": [
+        "item-body"
+      ],
+      "rel": [
+        "https://questions.api.brightspace.com/rels/item-body"
+      ],
+      "href": "./data/true-false/item-body.json"
+    }
+  ]
+}

--- a/test/data/true-false/response-declaration.json
+++ b/test/data/true-false/response-declaration.json
@@ -1,0 +1,57 @@
+{
+  "class": [
+    "response-declaration"
+  ],
+  "properties": {
+    "cardinality": "single",
+    "baseType": "identifier"
+  },
+  "entities": [
+    {
+      "class": [
+        "correct-response"
+      ],
+      "rel": [
+        "item"
+      ],
+      "entities": [
+        {
+          "class": [
+            "value"
+          ],
+          "rel": [
+            "item"
+          ],
+          "links": [
+            {
+              "rel": [
+                "https://questions.api.brightspace.com/rels/identifier"
+              ],
+              "href": "./data/true-false/simple-choice-1.json"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/item-body"
+      ],
+      "href": "#not-included-in-demo-data"
+    },
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/interaction"
+      ],
+      "href": "#not-included-in-demo-data"
+    },
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "#"
+    }
+  ]
+}

--- a/test/data/true-false/simple-choice-1.json
+++ b/test/data/true-false/simple-choice-1.json
@@ -1,0 +1,33 @@
+{
+  "class": [
+    "simple-choice"
+  ],
+  "entities": [
+    {
+      "class": [
+        "richtext"
+      ],
+      "rel": [
+        "https://questions.api.brightspace.com/rels/text"
+      ],
+      "properties": {
+        "text": "True",
+        "html": "True"
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/interaction"
+      ],
+      "href": "#not-included-in-demo-data"
+    },
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "#"
+    }
+  ]
+}

--- a/test/data/true-false/simple-choice-2.json
+++ b/test/data/true-false/simple-choice-2.json
@@ -1,0 +1,33 @@
+{
+  "class": [
+    "simple-choice"
+  ],
+  "entities": [
+    {
+      "class": [
+        "richtext"
+      ],
+      "rel": [
+        "https://questions.api.brightspace.com/rels/text"
+      ],
+      "properties": {
+        "text": "False",
+        "html": "False"
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "https://questions.api.brightspace.com/rels/interaction"
+      ],
+      "href": "#not-included-in-demo-data"
+    },
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "#"
+    }
+  ]
+}


### PR DESCRIPTION
https://rally1.rallydev.com/#/10153049633d/dashboard?detail=%2Fuserstory%2F605447991457

This is a massive PR but a majority of the changes are data files
In this PR:

1. Add true-false question case for in `components/d2l-questions-question.js`
2. Add file `components/d2l-questions-true-false-presentational.js` for displaying true-false question type
3. Add file `components/d2l-questions-true-false.js` for API related queries for the presentational component
4. Add Demo page and data
5. Add Vdiff tests and data